### PR TITLE
Fix DNS test failures in ci.centos.org

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -7,8 +7,8 @@ echo -e "\n[+] `date` -> CentOS QA $0 starting."
 
 yum -d0 -y install bind-utils 
 
-host repo.centos.qa > /dev/null
-export SKIP_QA_HARNESS=$?
+host repo.centos.qa > /dev/null && : ${SKIP_QA_HARNESS:=0} || : ${SKIP_QA_HARNESS:=1}
+export SKIP_QA_HARNESS
 
 LIB_FUNCTIONS='./tests/0_lib/functions.sh'
 

--- a/tests/0_common/30_dns_works.sh
+++ b/tests/0_common/30_dns_works.sh
@@ -2,7 +2,7 @@
 
 t_Log "Running $0 - testing to see if DNS works"
 if [ $SKIP_QA_HARNESS -eq 1 ]; then 
-  HOST=ci.dev.centos.org 
+  HOST=ci.centos.org
 else
   HOST=repo.centos.qa
 fi


### PR DESCRIPTION
The tests were failing in ci.centos.org because the DNS test was attempting to
ping ci.dev.centos.org which is no longer reachable. I tweaked this to ping
ci.centos.org which should be available.

I also wanted to be sure that the SKIP_QA_HARNESS environment variable was
maintained if specified in the environment. The host check in runtests.sh
overwrote the value no matter what.
