### PR TITLE
Do not run CentOS 5/6 tests on ppc64le

### DIFF
--- a/tests/0_lib/functions.sh
+++ b/tests/0_lib/functions.sh
@@ -43,15 +43,15 @@ function t_RemovePackage
 function t_Process
 {
 	exec 7< $@
-	
+
 	while read -u 7 f
 	do
 		# skip files named readme or those that start with an _
 		[[ "$(basename ${f})" =~ readme|^_ ]] &&  continue;
-		
+
 		# handy tip: chmod -x to disable individual test scripts.
 		[ -x ${f} ] && ${f}
-			
+
 	done
 
 	return 0
@@ -63,14 +63,14 @@ function t_Process
 function t_CheckDeps
 {
 	# TODO
-	
+
 	# success, all packages are installed
 	return 0
 }
 
 # Description: perform a service control and sleep for a few seconds to let
-#   the dust settle. Using this function avoids a race condition wherein 
-#   subsequent tests execute (and typically fail) before a service has had a 
+#   the dust settle. Using this function avoids a race condition wherein
+#   subsequent tests execute (and typically fail) before a service has had a
 #   chance to fully start/open a network port etc.
 # Call it with cycle instead of start, and it will stop+start
 #   handy, if you dont know the service might already be running
@@ -91,7 +91,7 @@ function t_ServiceControl
 # Description: Get a package (rpm) release number
 function t_GetPkgRel
 {
-       rpm -q --queryformat '%{RELEASE}' $1 
+       rpm -q --queryformat '%{RELEASE}' $1
 }
 
 # Description: return the distro release (returns 5 or 6 now)
@@ -105,10 +105,10 @@ centos_ver=$(t_DistCheck)
 # Description: Get a package (rpm) version number
 function t_GetPkgVer
 {
-       rpm -q --queryformat '%{version}' $1 
+       rpm -q --queryformat '%{version}' $1
 }
 
-# Description: get the arch 
+# Description: get the arch
 function t_GetArch
 {
 	rpm -q --queryformat '%{arch}\n' centos-release
@@ -136,7 +136,7 @@ function t_Assert
 
 function t_Assert_Equals
 {
- [ $1 -eq $2 ] 
+ [ $1 -eq $2 ]
  t_CheckExitStatus $?
 }
 export -f t_Log

--- a/tests/0_lib/functions.sh
+++ b/tests/0_lib/functions.sh
@@ -139,6 +139,29 @@ function t_Assert_Equals
  [ $1 -eq $2 ]
  t_CheckExitStatus $?
 }
+
+# Description: exit with $PASS if the current architecture matches one
+# of the given architectures.  Otherwise, do nothing.  This function
+# can be called at the very beginning of tests so they can be skipped
+# if running on given architectures.
+# Arguments: space-separated list of excluded architectures.
+function t_ExcludeArches
+{
+	excludedArches="$*"
+	currentArch=$(t_GetArch)
+
+	for excludedArch in ${excludedArches}
+	do
+		if [ "${currentArch}" == "${excludedArch}" ]
+		then
+			t_Log "Architecture is excluded, skipping."
+			t_Log "PASS"
+			exit ${PASS}
+		fi
+	done
+}
+
+
 export -f t_Log
 export -f t_CheckExitStatus
 export -f t_InstallPackage
@@ -153,4 +176,5 @@ export -f t_GetArch
 export -f t_CheckForPort
 export -f t_Assert
 export -f t_Assert_Equals
+export -f t_ExcludeArches
 export centos_ver

--- a/tests/p_docker/30_docker_centos5_img_runcmd.sh
+++ b/tests/p_docker/30_docker_centos5_img_runcmd.sh
@@ -3,8 +3,9 @@
 
 t_Log "Running $0 - Running a command inside CentOS 5 image "
 
+t_ExcludeArches "ppc64le"
+
 docker run centos:centos5 cat /etc/redhat-release | grep -q 'CentOS'
 
 
 t_CheckExitStatus $?
-

--- a/tests/p_docker/30_docker_centos6_img_runcmd.sh
+++ b/tests/p_docker/30_docker_centos6_img_runcmd.sh
@@ -3,8 +3,9 @@
 
 t_Log "Running $0 - Running a command inside CentOS 6 image "
 
+t_ExcludeArches "ppc64le"
+
 docker run centos:centos6 cat /etc/redhat-release | grep -q 'CentOS'
 
 
 t_CheckExitStatus $?
-

--- a/tests/p_docker/40_docker_centos5_img_hostname_match_cont_id.sh
+++ b/tests/p_docker/40_docker_centos5_img_hostname_match_cont_id.sh
@@ -3,10 +3,10 @@
 
 t_Log "Running $0 - Check if hostname inside CentOS 5 image matches container id"
 
+t_ExcludeArches "ppc64le"
 
 hostname_output="`docker run centos:centos5 hostname`"
 
 docker ps -a | grep -q "$hostname_output"
 
 t_CheckExitStatus $?
-

--- a/tests/p_docker/40_docker_centos6_img_hostname_match_cont_id.sh
+++ b/tests/p_docker/40_docker_centos6_img_hostname_match_cont_id.sh
@@ -3,10 +3,10 @@
 
 t_Log "Running $0 - Check if hostname inside CentOS 6 image matches container id"
 
+t_ExcludeArches "ppc64le"
 
 hostname_output="`docker run centos:centos6 hostname`"
 
 docker ps -a | grep -q "$hostname_output"
 
 t_CheckExitStatus $?
-


### PR DESCRIPTION
Blank spaces cleanup in functions.sh; add new function t_ExcludeArches to skip test on given architectures; and skip CentOS 5/6 tests on ppc64le.

* f3639f0 Do not run CentOS 5/6 tests on ppc64le
* 196a155 Add t_ExcludeArches function
* 3fc343d Remove trailing blank spaces from functions.sh